### PR TITLE
Fix links to frama-c.com and markdown header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-#ACSL by Example
+# ACSL by Example
 
 This repository contains
 [ACSL by Example](https://github.com/fraunhoferfokus/acsl-by-example/blob/master/ACSL-by-Example.pdf)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains
 [ACSL by Example](https://github.com/fraunhoferfokus/acsl-by-example/blob/master/ACSL-by-Example.pdf)
 --- a collection of C functions and data types whose
 behavior has been formally specified
-with [ACSL](https://www.frama-c.com/acsl.html) and formally verified with [Frama-C/WP](https://www.frama-c.com/wp.html).
+with [ACSL](https://frama-c.com/acsl.html) and formally verified with [Frama-C/WP](https://frama-c.com/wp.html).
 
 The directory
 [StandardAlgorithms](https://github.com/fraunhoferfokus/acsl-by-example/tree/master/StandardAlgorithms)


### PR DESCRIPTION
`www.frama-c.com` links lead to TLS certificate error. 